### PR TITLE
Added starting stars option to tribes

### DIFF
--- a/OpenPolytopia.Common/Tribe.cs
+++ b/OpenPolytopia.Common/Tribe.cs
@@ -63,6 +63,11 @@ public class Tribe {
   /// The terrain generation rates of a tribe
   /// </summary>
   public required TerrainRate TerrainRate { get; init; }
+
+  /// <summary>
+  /// The starting stars of a tribe
+  /// </summary>
+  public required int StartingStars { get; init; }
 }
 
 /// <summary>

--- a/OpenPolytopia.Common/resources/tribes.json
+++ b/OpenPolytopia.Common/resources/tribes.json
@@ -2,6 +2,7 @@
   "tribes": [
     {
       "type": "imperius",
+      "starting_stars": 7,
       "tribe": {
         "starting_tech": {
           "branch": "organization",


### PR DESCRIPTION
Now a tribe can specify how many stars it should start with.
The only tribe registered at the moment (Imperius) starts with 7 stars.